### PR TITLE
Add support for database hook/trigger

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,21 +24,21 @@
     "prepublishOnly": "rm -rf dist && yarn build"
   },
   "dependencies": {
-    "mongodb": "^3.5.2"
+    "mongodb": "^3.5.3"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.1",
-    "@types/mongodb": "^3.3.14",
-    "@types/node": "^13.1.6",
-    "@typescript-eslint/eslint-plugin": "^2.15.0",
-    "@typescript-eslint/parser": "^2.15.0",
+    "@types/jest": "^25.1.2",
+    "@types/mongodb": "^3.3.16",
+    "@types/node": "^13.7.1",
+    "@typescript-eslint/eslint-plugin": "^2.19.2",
+    "@typescript-eslint/parser": "^2.19.2",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.9.0",
-    "eslint-plugin-jest": "^23.4.0",
+    "eslint-plugin-jest": "^23.7.0",
     "eslint-plugin-prettier": "^3.1.2",
     "jest": "^25.1.0",
     "prettier": "^1.19.1",
-    "ts-jest": "^25.1.0",
+    "ts-jest": "^25.2.0",
     "typedoc": "^0.16.9",
     "typescript": "^3.7.4"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,7 +104,7 @@ export class Mongol {
     hook: DatabaseHook
   ): Collection<TSchema> {
     for (const fn of Object.values(CrudOperation)) {
-      const originalFn = collection[fn]
+      const originalFn = collection[fn].bind(collection)
       collection[fn] = this.withDatabaseHook(originalFn, hook, fn) as any
     }
     return collection

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,12 +14,14 @@ export interface SchemaOptions {
 
 /** CRUD operations supported by MongoDB [[Collection]].
  *
- * Mongol does not fully support all operations, especially deprecated ones.
+ * Mongol does not support all operations, especially deprecated ones.
  */
 export enum CrudOperation {
+  BulkWrite = 'bulkWrite',
   DeleteMany = 'deleteMany',
   DeleteOne = 'deleteOne',
-  FindOne = 'findOne',
+  // Find = 'find', // cannot support now
+  // FindOne = 'findOne', // do not want to support now
   FindOneAndDelete = 'findOneAndDelete',
   FindOneAndReplace = 'findOneAndReplace',
   FindOneAndUpdate = 'findOneAndUpdate',
@@ -30,6 +32,7 @@ export enum CrudOperation {
   UpdateOne = 'updateOne'
 }
 
+/** Database hook event. */
 type DatabaseHookEvent = 'before' | 'during' | 'after'
 
 interface DatabaseHookContext {

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,7 +45,7 @@ interface DatabaseHookContext {
 type DatabaseBeforeHookHandler = (
   context: DatabaseHookContext,
   ...args
-) => void | Promise<void>
+) => void | any[] | Promise<void> | Promise<any[]>
 
 /** Database hook "after" handler. */
 type DatabaseAfterHookHandler = (

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,19 +35,33 @@ export enum CrudOperation {
 /** Database hook event. */
 type DatabaseHookEvent = 'before' | 'during' | 'after'
 
+/** Database hook context. */
 interface DatabaseHookContext {
   operation: CrudOperation
   event: DatabaseHookEvent
 }
 
-type DatabaseBeforeHookHandler = (context: DatabaseHookContext, ...args) => void
+/** Database hook "before" handler. */
+type DatabaseBeforeHookHandler = (
+  context: DatabaseHookContext,
+  ...args
+) => void | Promise<void>
 
-type DatabaseAfterHookHandler = (context: DatabaseHookContext, result) => void
+/** Database hook "after" handler. */
+type DatabaseAfterHookHandler = (
+  context: DatabaseHookContext,
+  result
+) => void | Promise<void>
 
-// type DatabaseErrorHookHandler = (context: DatabaseHookContext, error: Error) => void
+/** Database hook "error" handler. */
+type DatabaseErrorHookHandler = (
+  context: DatabaseHookContext,
+  error: Error
+) => void | Promise<void>
 
+/** Database hook. */
 export interface DatabaseHook {
   before?: DatabaseBeforeHookHandler
   after?: DatabaseAfterHookHandler
-  // error?: DatabaseErrorHookHandler
+  error?: DatabaseErrorHookHandler
 }


### PR DESCRIPTION
This PR continues experiments with `Mongol.attachDatabaseHook()`.

- [x] Database hooks as event listeners, listening to document changes.
- [x] Fully support asynchronous hook handlers.
- [x] Throw error in "before" handler to cancel the real operation.
- [x] Database hooks can alter input.